### PR TITLE
ENH: Disable interpolation in design matrix

### DIFF
--- a/model_one_voxel.Rmd
+++ b/model_one_voxel.Rmd
@@ -71,7 +71,7 @@ regressor, and a column of ones:
 N = len(convolved)
 X = np.ones((N, 2))
 X[:, 0] = convolved
-plt.imshow(X, cmap='gray', aspect=0.1)
+plt.imshow(X, cmap='gray', aspect=0.1, interpolation='none')
 ```
 
 $\newcommand{\yvec}{\vec{y}}$


### PR DESCRIPTION
Current display shows blurring between columns, which is at best unhelpful, at worst confusing.

Before (jupyterbook):

![image](https://github.com/nipraxis/textbook/assets/83442/ca5cd794-8b47-446c-908c-bcfbbb679578)


After (jupyterhub):

![image](https://github.com/nipraxis/textbook/assets/83442/1b642b4a-401d-4b9c-9a3d-4f9fe428921d)
